### PR TITLE
Changes to unitwaittime

### DIFF
--- a/common/city.c
+++ b/common/city.c
@@ -3119,6 +3119,9 @@ struct city *create_city_virtual(struct player *pplayer,
   if (is_server()) {
     pcity->server.mgr_score_calc_turn = -1; /* -1 = never */
 
+    pcity->server.prod_change_timestamp = time(NULL);
+    pcity->server.prod_change_turn = game.info.turn;
+
     CALL_FUNC_EACH_AI(city_alloc, pcity);
   } else {
     pcity->client.info_units_supported =

--- a/common/city.h
+++ b/common/city.h
@@ -418,6 +418,10 @@ struct city {
       void *ais[FREECIV_AI_MOD_LAST];
 
       struct vision *vision;
+      
+      /* when city production was changed by player */
+      time_t prod_change_timestamp;
+      int prod_change_turn;
     } server;
 
     struct {

--- a/common/game.c
+++ b/common/game.c
@@ -455,6 +455,9 @@ static void game_defaults(void)
     game.server.timeoutintinc     = GAME_DEFAULT_TIMEOUTINTINC;
     game.server.turnblock         = GAME_DEFAULT_TURNBLOCK;
     game.server.unitwaittime      = GAME_DEFAULT_UNITWAITTIME;
+    game.server.unitwaittime_range    = GAME_DEFAULT_UNITWAITTIME_RANGE;
+    game.server.unitwaittime_allied   = GAME_DEFAULT_UNITWAITTIME_ALLIED;
+    game.server.playerwaittime        = GAME_DEFAULT_PLAYERWAITTIME;
     game.server.plr_colors        = NULL;
   } else {
     /* Client side takes care of itself in client_main() */

--- a/common/game.c
+++ b/common/game.c
@@ -457,6 +457,7 @@ static void game_defaults(void)
     game.server.unitwaittime      = GAME_DEFAULT_UNITWAITTIME;
     game.server.unitwaittime_range    = GAME_DEFAULT_UNITWAITTIME_RANGE;
     game.server.unitwaittime_allied   = GAME_DEFAULT_UNITWAITTIME_ALLIED;
+    game.server.unitwaittime_extended = GAME_DEFAULT_UNITWAITTIME_EXTENDED;
     game.server.playerwaittime        = GAME_DEFAULT_PLAYERWAITTIME;
     game.server.plr_colors        = NULL;
   } else {

--- a/common/game.h
+++ b/common/game.h
@@ -196,6 +196,9 @@ struct civ_game {
       int techpenalty;
       bool turnblock;
       int unitwaittime;   /* minimal time between two movements of a unit */
+      int unitwaittime_range;   /* range over which unitwaittime applies */
+      bool unitwaittime_allied;   /* does unitwaittime apply to allied units */
+      int playerwaittime;   /* minimal time between any two movements made by a player */
       unsigned unitwaittime_style;
       int upgrade_veteran_loss;
       bool vision_reveal_tiles;
@@ -583,6 +586,17 @@ extern struct civ_game game;
 #define GAME_MIN_UNITWAITTIME        0
 #define GAME_MAX_UNITWAITTIME        GAME_MAX_TIMEOUT
 #define GAME_DEFAULT_UNITWAITTIME    0
+
+#define GAME_MIN_UNITWAITTIME_RANGE       -1
+#define GAME_MAX_UNITWAITTIME_RANGE        10
+#define GAME_DEFAULT_UNITWAITTIME_RANGE   -1
+
+#define GAME_DEFAULT_UNITWAITTIME_ALLIED  FALSE
+
+#define GAME_MIN_PLAYERWAITTIME           0
+#define GAME_MAX_PLAYERWAITTIME           GAME_MAX_TIMEOUT
+#define GAME_DEFAULT_PLAYERWAITTIME       0
+
 
 #define GAME_DEFAULT_UNITWAITTIME_STYLE UWT_CLASSICAL
 

--- a/common/game.h
+++ b/common/game.h
@@ -198,6 +198,7 @@ struct civ_game {
       int unitwaittime;   /* minimal time between two movements of a unit */
       int unitwaittime_range;   /* range over which unitwaittime applies */
       bool unitwaittime_allied;   /* does unitwaittime apply to allied units */
+      bool unitwaittime_extended; /* UWT applies to built and captured/bribed units  */
       int playerwaittime;   /* minimal time between any two movements made by a player */
       unsigned unitwaittime_style;
       int upgrade_veteran_loss;
@@ -592,6 +593,8 @@ extern struct civ_game game;
 #define GAME_DEFAULT_UNITWAITTIME_RANGE   -1
 
 #define GAME_DEFAULT_UNITWAITTIME_ALLIED  FALSE
+
+#define GAME_DEFAULT_UNITWAITTIME_EXTENDED  FALSE
 
 #define GAME_MIN_PLAYERWAITTIME           0
 #define GAME_MAX_PLAYERWAITTIME           GAME_MAX_TIMEOUT

--- a/common/player.h
+++ b/common/player.h
@@ -316,6 +316,9 @@ struct player {
       int huts; /* How many huts this player has found */
 
       int bulbs_last_turn; /* Number of bulbs researched last turn only. */
+      
+      time_t action_timestamp;
+      int action_turn;
     } server;
 
     struct {

--- a/server/cityhand.c
+++ b/server/cityhand.c
@@ -371,6 +371,9 @@ void really_handle_city_buy(struct player *pplayer, struct city *pcity)
   }
   city_refresh(pcity);
 
+  /* Update action timestamp inherited by the bought unit */
+  city_did_prod_change(pcity);
+
   if (VUT_UTYPE == pcity->production.kind) {
     notify_player(pplayer, pcity->tile, E_UNIT_BUY, ftc_server,
                   /* TRANS: bought an unit. */

--- a/server/citytools.c
+++ b/server/citytools.c
@@ -1244,6 +1244,9 @@ bool transfer_city(struct player *ptaker, struct city *pcity,
       advisor_choose_build(ptaker, pcity);
     }
 
+    /* Update action timestamp inherited by any units being produced */
+    city_did_prod_change(pcity);
+
     /* What wasn't obsolete for the old owner may be so now. */
     remove_obsolete_buildings_city(pcity, TRUE);
 
@@ -2799,6 +2802,9 @@ void change_build_target(struct player *pplayer, struct city *pcity,
   /* Change build target. */
   pcity->production = *target;
 
+  /* Update action timestamp inherited by the unit being produced */
+  city_did_prod_change(pcity);
+
   /* What's the name of the target? */
   name = city_production_name_translation(pcity);
 
@@ -2839,6 +2845,17 @@ void change_build_target(struct player *pplayer, struct city *pcity,
                   name,
                   city_link(pcity));
   }
+}
+
+
+/**************************************************************************
+  City did something to change production. Used to set action
+  timestamps for new units.
+**************************************************************************/
+void city_did_prod_change(struct city *pcity)
+{
+  pcity->server.prod_change_timestamp = time(NULL);
+  pcity->server.prod_change_turn = game.info.turn;
 }
 
 /**************************************************************************

--- a/server/citytools.h
+++ b/server/citytools.h
@@ -103,4 +103,6 @@ void clear_worker_task(struct city *pcity, struct worker_task *ptask);
 void clear_worker_tasks(struct city *pcity);
 void package_and_send_worker_tasks(struct city *pcity);
 
+void city_did_prod_change(struct city *pcity);
+
 #endif  /* FC__CITYTOOLS_H */

--- a/server/cityturn.c
+++ b/server/cityturn.c
@@ -1987,7 +1987,7 @@ static bool city_distribute_surplus_shields(struct player *pplayer,
                       E_UNIT_LOST_MISC, ftc_server,
                       _("%s can't upkeep %s, unit disbanded."),
                       city_link(pcity), unit_link(punit));
-        handle_unit_disband(pplayer, punit->id);
+        unit_do_disband(pplayer, punit, FALSE);
 	/* pcity->surplus[O_SHIELD] is automatically updated. */
       }
     } unit_list_iterate_safe_end;

--- a/server/cityturn.c
+++ b/server/cityturn.c
@@ -2184,6 +2184,13 @@ static struct unit *city_create_unit(struct city *pcity,
   pplayer->score.units_built++;
   saved_unit_id = punit->id;
 
+  /* Initialize the new unit's action timestamp from when the city
+     production was changed or the unit bought */
+  if (game.server.unitwaittime_extended) {
+    punit->server.action_timestamp = pcity->server.prod_change_timestamp;
+    punit->server.action_turn = pcity->server.prod_change_turn;
+  }
+  
   /* This might destroy pcity and/or punit: */
   script_server_signal_emit("unit_built", 2,
                             API_TYPE_UNIT, punit,

--- a/server/diplomats.c
+++ b/server/diplomats.c
@@ -513,6 +513,11 @@ void diplomat_bribe(struct player *pplayer, struct unit *pdiplomat,
     return;
   }
 
+  if (game.server.unitwaittime_extended) {
+    /* Counts as an action even if the move to be tried doesn't succeed */
+    unit_did_action(pdiplomat);
+  }
+
   /* Try to move the briber onto the victim's square unless the victim has
    * been bounced because it couldn't share tile with a unit or city. */
   if (!bounce

--- a/server/plrhand.c
+++ b/server/plrhand.c
@@ -1356,6 +1356,9 @@ void server_player_init(struct player *pplayer, bool initmap,
 {
   player_status_reset(pplayer);
 
+  pplayer->server.action_timestamp = 0;
+  pplayer->server.action_turn = -2; /* before any actual turn */
+
   pplayer->server.got_first_city = FALSE;
   BV_CLR_ALL(pplayer->server.really_gives_vision);
   BV_CLR_ALL(pplayer->server.debug);

--- a/server/settings.c
+++ b/server/settings.c
@@ -2741,6 +2741,15 @@ static struct setting settings[] = {
              "This has no effect if 'unitwaittime_range' is set to -1."),
           NULL, NULL, GAME_DEFAULT_UNITWAITTIME_ALLIED)
 
+  GEN_BOOL("unitwaittime_extended", game.server.unitwaittime_extended,
+          SSET_RULES_FLEXIBLE, SSET_INTERNAL, SSET_VITAL, SSET_TO_CLIENT,
+          N_("Unitwaittime also applies to newly-built and captured/bribed units."),
+          N_("If set, newly-built units are subject to unitwaittime so that "
+             "the moment the city production was last touched counts as their "
+             "last \"action\". Also, getting captured/bribed counts as action "
+             "for the victim. "),
+          NULL, NULL, GAME_DEFAULT_UNITWAITTIME_EXTENDED)
+
   GEN_INT("playerwaittime", game.server.playerwaittime,
           SSET_RULES_FLEXIBLE, SSET_INTERNAL, SSET_VITAL, SSET_TO_CLIENT,
           N_("Minimum time between player actions over turn change"),

--- a/server/settings.c
+++ b/server/settings.c
@@ -2715,6 +2715,48 @@ static struct setting settings[] = {
           NULL, unitwaittime_callback, NULL, GAME_MIN_UNITWAITTIME,
           GAME_MAX_UNITWAITTIME, GAME_DEFAULT_UNITWAITTIME)
 
+  GEN_INT("unitwaittime_range", game.server.unitwaittime_range,
+          SSET_RULES_FLEXIBLE, SSET_INTERNAL, SSET_VITAL, SSET_TO_CLIENT,
+          N_("Distance over which 'unitwaittime' applies when moving"),
+          /* TRANS: The string between single quotes is a setting name and
+           * should not be translated. */
+          N_("This setting gives the range over which units affect other "
+             "units for 'unitwaittime' restrictions. "
+             "If set to -1, unit moves only affect further moves of the "
+             "same unit (default). "
+             "If >= 0, wait times of units within this range are checked "
+             "when a unit tries to move. (0 = same tile, 1 = neighboring "
+             "tiles, etc.). "),
+          NULL, NULL, NULL, GAME_MIN_UNITWAITTIME_RANGE,
+          GAME_MAX_UNITWAITTIME_RANGE, GAME_DEFAULT_UNITWAITTIME_RANGE)
+
+  GEN_BOOL("unitwaittime_allied", game.server.unitwaittime_allied,
+          SSET_RULES_FLEXIBLE, SSET_INTERNAL, SSET_VITAL, SSET_TO_CLIENT,
+          N_("Allied units also count for 'unitwaittime_range' restrictions"),
+          /* TRANS: The string between single quotes is a setting name and
+           * should not be translated. */
+          N_("If set, allied units within 'unitwaittime_range' also "
+             "affect units for 'unitwaittime' restrictions. If unset, "
+             "only units of the same player are checked. "
+             "This has no effect if 'unitwaittime_range' is set to -1."),
+          NULL, NULL, GAME_DEFAULT_UNITWAITTIME_ALLIED)
+
+  GEN_INT("playerwaittime", game.server.playerwaittime,
+          SSET_RULES_FLEXIBLE, SSET_INTERNAL, SSET_VITAL, SSET_TO_CLIENT,
+          N_("Minimum time between player actions over turn change"),
+          /* TRANS: The string between single quotes is a setting name and
+           * should not be translated. */
+          N_("Similarly to 'unitwaittime', this setting gives the minimum time "
+             "between ANY unit moves made by a player over a turn change. "
+             "For example, if this setting is set to 20 and a player moves "
+             "a unit 5 seconds before the turn change, that player will not "
+             "be able to move ANY units (neither the same unit nor others) "
+             "in the next turn for 15 seconds. This value should be limited "
+             "to a maximum value proportional to 'timeout', but this is not "
+             "enforced."),
+          NULL, NULL, NULL, GAME_MIN_PLAYERWAITTIME,
+          GAME_MAX_PLAYERWAITTIME, GAME_DEFAULT_PLAYERWAITTIME)
+
   GEN_BITWISE("unitwaittime_style", game.server.unitwaittime_style,
               SSET_RULES_FLEXIBLE, SSET_INTERNAL, SSET_VITAL,
               SSET_TO_CLIENT,

--- a/server/unithand.h
+++ b/server/unithand.h
@@ -34,6 +34,9 @@ bool unit_move_handling(struct unit *punit, struct tile *pdesttile,
 bool unit_build_city(struct player *pplayer, struct unit *punit,
                      const char *name);
 
+void unit_do_disband(struct player *pplayer, struct unit *punit, 
+                     bool voluntary);
+
 void city_add_or_build_error(struct player *pplayer, struct unit *punit,
                              enum unit_add_build_city_result res);
 

--- a/server/unittools.c
+++ b/server/unittools.c
@@ -2052,6 +2052,11 @@ struct unit *unit_change_owner(struct unit *punit, struct player *pplayer,
   gained_unit->paradropped = punit->paradropped;
   gained_unit->server.birth_turn = punit->server.birth_turn;
 
+  if (game.server.unitwaittime_extended) {
+    /* Counts as an action for unitwaittime */
+    unit_did_action(gained_unit);
+  }
+
   send_unit_info(NULL, gained_unit);
 
   /* update unit upkeep in the homecity of the victim */

--- a/server/unittools.c
+++ b/server/unittools.c
@@ -4533,11 +4533,115 @@ void unit_list_refresh_vision(struct unit_list *punitlist)
   } unit_list_iterate_end;
 }
 
+
 /****************************************************************************
-  Used to implement the game rule controlled by the unitwaittime setting.
+  Used to implement the game rules controlled by the unitwaittime and
+  playerwaittime settings, including possible extensions like
+  unitwaittime_range.
+  
   Notifies the unit owner if the unit is unable to act.
 ****************************************************************************/
 bool unit_can_do_action_now(const struct unit *punit)
+{  
+  int range = game.server.unitwaittime_range;
+  int time_remaining = 0;
+  
+  if (!punit) {
+    return FALSE;
+  }
+  
+  /* check playerwaittime first */
+  if (! player_can_do_action_now(unit_owner(punit), &time_remaining)) {
+    char buf[64];
+    format_time_duration(time_remaining, buf, sizeof(buf));
+    notify_player(unit_owner(punit), unit_tile(punit), E_BAD_COMMAND,
+                  ftc_server, _("You may not act for another %s "
+                                "this turn. See /help playerwaittime."), buf);
+    return FALSE;  
+  }
+
+  if (game.server.unitwaittime <= 0) {
+    return TRUE;
+  }
+      
+  if (range < 0) {
+    /* traditional behavior: only check the unit itself */
+    if (! unit_can_do_action_now_single(punit, &time_remaining)) {
+      char buf[64];
+      format_time_duration(time_remaining, buf, sizeof(buf));
+      notify_player(unit_owner(punit), unit_tile(punit), E_BAD_COMMAND,
+                    ftc_server, _("Your unit may not act for another %s "
+                                  "this turn. See /help unitwaittime."), buf);
+      return FALSE;
+    } else {
+      return TRUE;
+    }
+  } else {
+    /* check the neighboring squares too */
+    return unit_can_do_action_now_square(punit, range);
+  }
+}
+
+/****************************************************************************
+  Check the unitwaittime for all units within a square centered on punit.
+  If there are units that cannot move, return false and a send a
+  notification containing the type of the unit with longest time remaining.
+****************************************************************************/
+bool unit_can_do_action_now_square(const struct unit *punit, int range)
+{
+  int time_remaining = 0;
+  struct unit *runit = NULL; /* most restrictive unit */
+  bool check_allies = game.server.unitwaittime_allied;
+  
+  /* loop over all nearby owned (and possibly allied) units
+     and find the one with longest UWT remaining. */
+  square_iterate(unit_tile(punit), range, atile) {
+    unit_list_iterate(atile->units, aunit) {
+      int t = 0;
+      if (unit_owner(punit) == unit_owner(aunit) ||
+          (check_allies && pplayers_allied(unit_owner(punit), unit_owner(aunit)))
+         ) {
+        if (! unit_can_do_action_now_single(aunit, &t)) {
+          if (t > time_remaining) {
+            time_remaining = t;
+            runit = aunit;
+          }
+        }
+      }
+    } unit_list_iterate_end;
+  } square_iterate_end;
+
+  if (! runit) {
+    /* no conflicting units, movement allowed */
+    return TRUE;
+  }
+
+  /* punit itself or some nearby unit causes a conflict */
+  char buf[64];
+  format_time_duration(time_remaining, buf, sizeof(buf));
+  if (runit != punit) {
+    bool allied = (unit_owner(punit) != unit_owner(runit));
+    notify_player(unit_owner(punit), unit_tile(punit), E_BAD_COMMAND,
+                  ftc_server, _("Your %s may not act for another %s "
+                                "this turn (due to a nearby %s%s). "
+                                "See /help unitwaittime_range."), 
+                                unit_name_translation(punit), buf,
+                                allied ? "allied " : "",
+                                unit_name_translation(runit));
+  } else {
+    notify_player(unit_owner(punit), unit_tile(punit), E_BAD_COMMAND,
+                  ftc_server, _("Your %s may not act for another %s "
+                                "this turn. See /help unitwaittime."), 
+                                unit_name_translation(punit), buf);
+  }
+  return FALSE;
+}
+
+/****************************************************************************
+  Check the unitwaittime for a single unit, used as helper
+  by unit_can_do_action_now().
+****************************************************************************/
+bool unit_can_do_action_now_single(const struct unit *punit, int *time_remaining)
 {
   time_t dt;
 
@@ -4552,32 +4656,73 @@ bool unit_can_do_action_now(const struct unit *punit)
   if (punit->server.action_turn != game.info.turn - 1) {
     return TRUE;
   }
-
+ 
   dt = time(NULL) - punit->server.action_timestamp;
   if (dt < game.server.unitwaittime) {
-    char buf[64];
-    format_time_duration(game.server.unitwaittime - dt, buf, sizeof(buf));
-    notify_player(unit_owner(punit), unit_tile(punit), E_BAD_COMMAND,
-                  ftc_server, _("Your unit may not act for another %s "
-                                "this turn. See /help unitwaittime."), buf);
+    if (time_remaining) {
+      *time_remaining = game.server.unitwaittime - dt;
+    }
     return FALSE;
   }
 
   return TRUE;
 }
 
+
+/**************************************************************************** 
+  Implement player wait time (PWT), a generalization of unit wait time (UWT).
+  Controlled by the playerwaittime setting. This is called from
+  unit_can_do_action_now(), which is also responsible for notifying the
+  player.
+****************************************************************************/
+bool player_can_do_action_now(const struct player *pplayer, int *time_remaining)
+{
+  time_t dt;
+  int playerwaittime = game.server.playerwaittime;
+
+  if (!pplayer) {
+    return FALSE;
+  }
+
+  if (playerwaittime <= 0) {
+    return TRUE;
+  }
+
+  if (pplayer->server.action_turn != game.info.turn - 1) {
+    return TRUE;
+  }
+ 
+  dt = time(NULL) - pplayer->server.action_timestamp;
+  if (dt < playerwaittime) {
+    if (time_remaining) {
+      *time_remaining = playerwaittime - dt;
+    }
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+
+
 /****************************************************************************
-  Mark a unit as having done something at the current time. This is used
-  in conjunction with unit_can_do_action_now() and the unitwaittime setting.
+  Mark a unit and its owner as having done something at the current time. 
+  This is used in conjunction with unit_can_do_action_now() and the 
+  unitwaittime and playerwaittime settings.
 ****************************************************************************/
 void unit_did_action(struct unit *punit)
 {
+  struct player *pplayer = NULL;
   if (!punit) {
     return;
   }
 
   punit->server.action_timestamp = time(NULL);
   punit->server.action_turn = game.info.turn;
+  
+  pplayer = unit_owner(punit);
+  pplayer->server.action_timestamp = time(NULL);
+  pplayer->server.action_turn = game.info.turn;
 }
 
 /**************************************************************************

--- a/server/unittools.h
+++ b/server/unittools.h
@@ -155,6 +155,9 @@ bool unit_move(struct unit *punit, struct tile *ptile, int move_cost,
 bool execute_orders(struct unit *punit, const bool fresh);
 
 bool unit_can_do_action_now(const struct unit *punit);
+bool unit_can_do_action_now_square(const struct unit *punit, int range);
+bool unit_can_do_action_now_single(const struct unit *punit, int *time_remaining);
+bool player_can_do_action_now(const struct player *pplayer, int *time_remaining);
 void unit_did_action(struct unit *punit);
 
 bool unit_can_be_retired(struct unit *punit);


### PR DESCRIPTION
Add options to make UWT affect nearby units too, as well as newly-built and captured/bribed units.  Also playerwaittime.