### PR TITLE
Issue #11: Windows compile broken due to including endian.h

### DIFF
--- a/server/scripting/pbkdf2_sha256.c
+++ b/server/scripting/pbkdf2_sha256.c
@@ -28,7 +28,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#if !defined(FREECIV_MSWINDOWS) && !defined(_WIN32) && !defined(__WIN32__) && !defined(WIN32_NATIVE)
 #include <endian.h>
+#endif
 
 #include "pbkdf2_sha256.h"
 


### PR DESCRIPTION
I see these multiple windows defines being used. 
```_WIN32``` was the one that worked in my build environment, but I included the others as I see them being used elsewhere.
